### PR TITLE
Better handling of null mappings

### DIFF
--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -78,7 +78,7 @@ class FacetFrame:
             #         raise ValueError(
             #             "If spatial_columns is not provided, nodes must have 3 columns"
             #         )
-        self.nodes: pd.DataFrame = nodes
+        self.nodes: pd.DataFrame = nodes.copy()
 
         if spatial_columns is None:
             spatial_columns = []

--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -74,13 +74,7 @@ class FacetFrame:
                     raise ValueError("Nodes must be an nx3 array")
             else:
                 raise ValueError("Nodes must be a DataFrame or an nx3 array")
-            # if spatial_columns is None:
-            #     if nodes.shape[1] != 3:
-            #         raise ValueError(
-            #             "If spatial_columns is not provided, nodes must have 3 columns"
-            #         )
-
-        if copy:
+       if copy:
             nodes = nodes.copy()
         self.nodes: pd.DataFrame = nodes
 

--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -74,7 +74,13 @@ class FacetFrame:
                     raise ValueError("Nodes must be an nx3 array")
             else:
                 raise ValueError("Nodes must be a DataFrame or an nx3 array")
-       if copy:
+            # if spatial_columns is None:
+            #     if nodes.shape[1] != 3:
+            #         raise ValueError(
+            #             "If spatial_columns is not provided, nodes must have 3 columns"
+            #         )
+
+        if copy:
             nodes = nodes.copy()
         self.nodes: pd.DataFrame = nodes
 

--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -62,6 +62,7 @@ class FacetFrame:
         facets,
         spatial_columns: Optional[list] = None,
         relation_columns: Optional[list] = None,
+        inplace_data: bool = False,
     ):
         if not isinstance(nodes, pd.DataFrame):
             if isinstance(nodes, np.ndarray):
@@ -78,7 +79,10 @@ class FacetFrame:
             #         raise ValueError(
             #             "If spatial_columns is not provided, nodes must have 3 columns"
             #         )
-        self.nodes: pd.DataFrame = nodes.copy()
+        if not inplace_data:
+            self.nodes: pd.DataFrame = nodes.copy()
+        else:
+            self.nodes = nodes
 
         if spatial_columns is None:
             spatial_columns = []
@@ -90,7 +94,10 @@ class FacetFrame:
             facets = pd.DataFrame(facets)
             if relation_columns is None:
                 relation_columns = facets.columns.tolist()
-        self.facets: pd.DataFrame = facets
+        if inplace_data:
+            self.facets: pd.DataFrame = facets
+        else:
+            self.facets = facets.copy()
 
         if relation_columns is None:
             relation_columns = []

--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -62,7 +62,7 @@ class FacetFrame:
         facets,
         spatial_columns: Optional[list] = None,
         relation_columns: Optional[list] = None,
-        inplace_data: bool = False,
+        copy: bool = False,
     ):
         if not isinstance(nodes, pd.DataFrame):
             if isinstance(nodes, np.ndarray):
@@ -180,17 +180,6 @@ class FacetFrame:
         new_facets = self.facets[
             self.facets[self.relation_columns].isin(new_index).all(axis=1)
         ]
-
-        # new  node_mapping = {k: v for v, k in enumerate(new_index)}
-        # select_facets = self.facets[self.facets.isin(new_index).all(axis=1)]
-        # select_facet_array = select_facets[self.relation_columns].values
-        # # new_facets = fastremap.remap(select_facets, node_mapping)
-        # new_facet_array = np.vectorize(
-        #     lambda x: node_mapping.get(x, -1), otypes=[select_facet_array.dtype]
-        # )(select_facet_array)
-        # new_facets = select_facets.copy()
-        # new_facets[self.relation_columns] = new_facet_array
-        # print(self.get_params())
         out = self.__class__((new_nodes, new_facets), **self.get_params())
         return out
 
@@ -200,7 +189,6 @@ class FacetFrame:
 
     def get_params(self):
         return {
-            "layer_type": self.layer_type,
             "spatial_columns": self.spatial_columns,
             "relation_columns": self.relation_columns,
         }

--- a/src/morphsync/base.py
+++ b/src/morphsync/base.py
@@ -79,10 +79,10 @@ class FacetFrame:
             #         raise ValueError(
             #             "If spatial_columns is not provided, nodes must have 3 columns"
             #         )
-        if not inplace_data:
-            self.nodes: pd.DataFrame = nodes.copy()
-        else:
-            self.nodes = nodes
+
+        if copy:
+            nodes = nodes.copy()
+        self.nodes: pd.DataFrame = nodes
 
         if spatial_columns is None:
             spatial_columns = []
@@ -94,10 +94,9 @@ class FacetFrame:
             facets = pd.DataFrame(facets)
             if relation_columns is None:
                 relation_columns = facets.columns.tolist()
-        if inplace_data:
-            self.facets: pd.DataFrame = facets
-        else:
-            self.facets = facets.copy()
+        if copy:
+            facets = facets.copy()
+        self.facets: pd.DataFrame = facets
 
         if relation_columns is None:
             relation_columns = []
@@ -121,11 +120,6 @@ class FacetFrame:
     def points(self) -> np.ndarray:
         """Alias for vertices"""
         return self.vertices
-
-    # @property
-    # def points_df(self):
-    #     """Alias for vertices_df"""
-    #     return self.vertices_df
 
     @property
     def n_nodes(self) -> int:
@@ -200,8 +194,13 @@ class FacetFrame:
         out = self.__class__((new_nodes, new_facets), **self.get_params())
         return out
 
+    @property
+    def layer_type(self) -> str:
+        return str(self.__class__).strip(">'").split(".")[-1].lower()
+
     def get_params(self):
         return {
+            "layer_type": self.layer_type,
             "spatial_columns": self.spatial_columns,
             "relation_columns": self.relation_columns,
         }

--- a/src/morphsync/morph.py
+++ b/src/morphsync/morph.py
@@ -347,33 +347,10 @@ class MorphSync:
     def get_masking(self, source, target, source_index=None):
         """Gets any elements from another layer that map to any of source_index."""
 
-        # warning about pending deprecation for using this function at all:
-        print("Warning: get_masking is deprecated, use new get_mapping")
-
-        if source_index is None:
-            source_index = self._layers[source].nodes_index
-        else:
-            if not isinstance(source_index, pd.Index):
-                source_index = pd.Index(source_index)
-
-        current_index = source_index.values.copy()
-        current_index = np.unique(current_index)
-        for current_source, current_target in nx.utils.pairwise(
-            self.get_link_path(source, target)
-        ):
-            mapping_series = self._links[(current_source, current_target)].set_index(
-                current_source
-            )[current_target]
-
-            # NOTE: this is somewhat slow but not as bad as the loc
-            intersection = mapping_series.index.intersection(current_index)
-
-            # NOTE this is the slow part
-            current_index = mapping_series.loc[intersection].values
-
-            current_index = np.unique(current_index)
-
-        return current_index
+        mapping = self.get_mapping(source, target, source_index, dropna=True)
+        target_ids = mapping.values
+        target_ids = np.unique(target_ids)
+        return target_ids
 
     def get_mapped_nodes(self, source, target, source_index=None, replace_index=True):
         """

--- a/src/morphsync/morph.py
+++ b/src/morphsync/morph.py
@@ -240,6 +240,7 @@ class MorphSync:
         target: str,
         source_index: Optional[Union[np.ndarray, pd.Index]] = None,
         validate=None,
+        null_strategy: str = "drop",
     ) -> pd.DataFrame:
         """
         Find mappings from source to target layers using the entire link graph, and
@@ -257,20 +258,22 @@ class MorphSync:
         validate : str, optional
             Whether to validate the mapping at each step. If specified, checks if each
             mapping between layers is of the specified type. Options are:
-            - “one_to_one” or “1:1”: check if join keys are unique in both source and target layers.
-            - “one_to_many” or “1:m”: check if join keys are unique in the source dataset.
-            - “many_to_one” or “m:1”: check if join keys are unique in the target dataset.
-            - “many_to_many” or “m:m”: allowed, but does not result in checks.
+            - "one_to_one" or "1:1": check if join keys are unique in both source and target layers.
+            - "one_to_many" or "1:m": check if join keys are unique in the source dataset.
+            - "many_to_one" or "m:1": check if join keys are unique in the target dataset.
+            - "many_to_many" or "m:m": allowed, but does not result in checks.
+        null_strategy : str, default "drop"
+            How to handle incomplete mappings:
+            - "drop": Remove rows with any null mappings
+            - "keep": Return with NaN values for missing mappings
+            - "sentinel": Use -1 for missing mappings (backward compatibility)
 
         Returns
         -------
         :
             Mapped indices in the target layer corresponding to the source_index in the
-            source layer. Note that there may be duplicates or -1 values if the
-            mapping is not one-to-one. -1 denotes null or no mapping.
+            source layer. Format depends on null_strategy parameter.
         """
-        # TODO: make this operate on the mappings themselves and then only apply to
-        # the index at the end
         if source_index is None:
             source_index = self._layers[source].nodes_index
         else:
@@ -285,9 +288,7 @@ class MorphSync:
             mapping_series = (
                 self._links[(current_source, current_target)]
                 .set_index(current_source)[current_target]
-                .drop(
-                    -1, errors="ignore"
-                )  # not sure if necessary but being safe for now
+                .astype("Int64")  # Use nullable integers internally
             )
             # catch pandas MergeError due to validate here, raise a more informative error
 
@@ -300,15 +301,30 @@ class MorphSync:
                     f"Mapping from '{current_source}' to '{current_target}' failed validation '{validate}'."
                 ) from e
 
-            # TODO decide whether to use -1 or NaN for unmapped
-            joined_mapping[current_target] = (
-                joined_mapping[current_target].fillna(-1).astype(int)
-            )
         joined_mapping = joined_mapping.loc[source_index]
+
+        # Apply null strategy at the end
+        match null_strategy:
+            case "drop":
+                return joined_mapping.dropna()
+            case "keep":
+                return joined_mapping  # Keep NaN/pd.NA values
+            case "sentinel":
+                return joined_mapping.fillna(-1).astype(int)  # Legacy behavior
+            case _:
+                raise ValueError(
+                    f"Unknown null_strategy: {null_strategy}. Use 'drop', 'keep', or 'sentinel'."
+                )
+
         return joined_mapping
 
     def get_mapping(
-        self, source: str, target: str, source_index=None, validate=None, dropna=True
+        self,
+        source: str,
+        target: str,
+        source_index=None,
+        validate=None,
+        null_strategy: str = "drop",
     ) -> pd.Series:
         """
         Find mappings from source to target layers using the entire link graph.
@@ -325,36 +341,38 @@ class MorphSync:
         validate : str, optional
             Whether to validate the mapping at each step. If specified, checks if each
             mapping between layers is of the specified type. Options are:
-            - “one_to_one” or “1:1”: check if join keys are unique in both source and target layers.
-            - “one_to_many” or “1:m”: check if join keys are unique in the source dataset.
-            - “many_to_one” or “m:1”: check if join keys are unique in the target dataset.
-            - “many_to_many” or “m:m”: allowed, but does not result in checks.
-        dropna : bool, default True
-            Whether to drop -1/null values (no mapping) from the output.
+            - "one_to_one" or "1:1": check if join keys are unique in both source and target layers.
+            - "one_to_many" or "1:m": check if join keys are unique in the source dataset.
+            - "many_to_one" or "m:1": check if join keys are unique in the target dataset.
+            - "many_to_many" or "m:m": allowed, but does not result in checks.
+        null_strategy : str, default "drop"
+            How to handle incomplete mappings:
+            - "drop": Remove entries with null mappings
+            - "keep": Return with NaN values for missing mappings
+            - "sentinel": Use -1 for missing mappings (backward compatibility)
 
         Returns
         -------
         :
             Series with nodes in the source layer as the index and mapped nodes in
-            the target layer as the values. Note that there may be duplicates or -1
-            values if the mapping is not one-to-one. -1 denotes null or no mapping.
+            the target layer as the values. Format depends on null_strategy parameter.
 
         Notes
         -----
-        This function is a convenience wrapper around `get_mapping_path` that returns
+        This function is a convenience wrapper around `get_mapping_paths` that returns
         just the final mapping as a Series. If you need to see the full mapping at
-        each step, use `get_mapping_path`.
+        each step, use `get_mapping_paths`.
         """
-        mapping_path = self.get_mapping_paths(source, target, source_index, validate)
+        mapping_path = self.get_mapping_paths(
+            source, target, source_index, validate, null_strategy
+        )
         mapping = mapping_path.set_index(source)[target]
-        if dropna:
-            mapping = mapping[mapping != -1]
         return mapping
 
     def get_masking(self, source, target, source_index=None):
         """Gets any elements from another layer that map to any of source_index."""
 
-        mapping = self.get_mapping(source, target, source_index, dropna=True)
+        mapping = self.get_mapping(source, target, source_index, null_strategy="drop")
         target_ids = mapping.values
         target_ids = np.unique(target_ids)
         return target_ids
@@ -370,7 +388,7 @@ class MorphSync:
             source_index = self._layers[source].nodes_index
 
         mapping = self.get_mapping(
-            source, target, source_index, validate=validate, dropna=True
+            source, target, source_index, validate=validate, null_strategy="drop"
         )
         target_index = mapping.values
         out = self._layers[target].nodes.reindex(target_index)
@@ -430,7 +448,7 @@ class MorphSync:
         return new_morphology
 
     def get_link_as_layer(self, source, target):
-        mapping = self.get_mapping(source, target)
+        mapping = self.get_mapping(source, target, null_strategy="drop")
         source_index = mapping.index
         target_index = mapping.values
         source_nodes = self._layers[source].nodes.loc[source_index]


### PR DESCRIPTION
I ran into an issue with keeping track of mappings that had nulls in them, and Claude suggested a fix that allowed different approaches to keeping or ignoring null mappings. There was also a small bug where `Facet.get_params()` was being passed  with keyword expansion with `layer_type` as a key, but I think you removed `layer_type` from the argument.

I might have messed up something git-related, but this version is now working for me.